### PR TITLE
Fixing problem with passing variables to docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ script:
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       docker run --rm \
         --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
-        --env ELECTRON_CACHE="/root/.cache/electron"
-        --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder"
+        --env ELECTRON_CACHE="/root/.cache/electron" \
+        --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
         -v ${PWD}:/project \
         -v ~/.cache/electron:/root/.cache/electron \
         -v ~/.cache/electron-builder:/root/.cache/electron-builder \

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ script:
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       docker run --rm \
         --env-file <(env | grep -iE 'DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
+        --env ELECTRON_CACHE="/root/.cache/electron"
+        --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder"
         -v ${PWD}:/project \
         -v ~/.cache/electron:/root/.cache/electron \
         -v ~/.cache/electron-builder:/root/.cache/electron-builder \


### PR DESCRIPTION
Making sure that ELECTRON_CACHE and ELECTRON_BUILDER_CACHE are using /root/.cache instead of /home/travis/.cache (which is valid in the travis runner environment, but not on inside electronuserland/builder:wine)